### PR TITLE
Order record by timestamp desc

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -196,7 +196,7 @@ const onGetHookRecords: RouteHandlerMethodWithCustomRouteGeneric<{
       },
       sort: [
         {
-          id: {
+          timestamp: {
             order: 'desc',
           },
         },


### PR DESCRIPTION
request-bucketのurlやopensearchに利用するidは内部的にuuidv7をencodeしたものを利用しています。
https://github.com/dayflower/request-bucket/blob/606c0f6aa2e7f20409950585aa2fc4d05346d48a/server/main.ts#L113

https://github.com/dayflower/request-bucket/blob/f13a84c63736a099476e6714bd33bb978e48fc6d/server/uuid62.ts#L11

現在これを逆順にsortして表示に利用しています。
しかし、これではtimestampの逆順とは異なる結果にソートされるようです。

表示順をtimestampの降順にするには、すでに利用しているidを変えるのではなく、opensearchへのクエリに直接timestampの降順を指定するのが良さそう!となりました。そのパッチです!

## なぜ?
まずは、applicationで使っている`uuid62`をdecodeし直して、確かめました。

```js
const baseX = (await import('base-x')).default;

const { v7 } = await import('uuid');

const base62 = baseX('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');

const uuid62 = () => {
  const buf = new Uint8Array(16);
  v7({}, buf);
  return base62.encode(buf);
};



const getUuidV7Date = (bytes) => {
  let big = 0n;
  for (const b of bytes) {
    big = (big << 8n) + BigInt(b);
  }

  // 上位60bitが timestamp (ミリ秒精度のUnix時間 << 12 | sub-millisecond)
  const timestamp60 = (big >> 68n) & ((1n << 60n) - 1n);

  // ミリ秒単位に変換: 下位12bitを除去するため、4096で割る
  const millis = timestamp60 / 4096n;

  return new Date(Number(millis));
}


const test = (encodedUuid) => {
    const uuidArray = base62.decode(encodedUuid);
    const tsBigInt = getUuidV7Date(uuidArray);
    console.log(`timestamp for ${encodedUuid} =`, tsBigInt.toString());
}

test("2ZjhHQ7pnJEaxklvAdA7H"); // 2025-03-10T04:37:00.925Z
// timestamp for 2ZjhHQ7pnJEaxklvAdA7H = Mon Mar 10 2025 13:37:00 GMT+0900 (Japan Standard Time)
test("2ZjVMc5M8aDus8oicK7Fq"); // 2025-03-11T07:49:48.178Z
// timestamp for 2ZjVMc5M8aDus8oicK7Fq = Tue Mar 11 2025 16:49:48 GMT+0900 (Japan Standard Time)

// 上の文字をreverse sortしてみる
const array = ["2ZjhHQ7pnJEaxklvAdA7H", "2ZjVMc5M8aDus8oicK7Fq"];
console.log(`reverse sorted:`, array.sort().reverse());
// reverse sorted: [ '2ZjhHQ7pnJEaxklvAdA7H', '2ZjVMc5M8aDus8oicK7Fq' ]
```
再現は出来ました。2025-03-10が2025-03-11よりも降順では最初にやってきます。

encode後の文字列がtimestampでソートした場合と同じように可能であるためには、与える文字列長が固定(uuidなのでyes)であることと、timesetampが文字列の先頭に記載されており(uuidv7なのでyes)`base62` がascii文字の昇順(0..9A..Za..z)で並んでいる必要(no)があります。
今の`base62`定義は `ascii文字の昇順(0..9A..Za..z)` ではなく `(0..9a..zA..Z)` なので、encode後の文字列でソートしても、基数変換時に大小関係が崩れているので、元のuuidのソートとは異なる結果になってしまいます。

例えば、現在の設定で10, 36をdecodeするとa(0x61, 97), A(0x41, 65)となりますが、これをソートするとA, aとなり、順番がひっくり返ります。
`base62` 自体の定義を変えることもできますが、その場合は既存の動いているアプリケーションに問題が出るので、変えずに直接timestampでソートするので間違いないと思います。

https://www.npmjs.com/package/base-x を見ると、base58まではascii文字の昇順で並んでいたのにそれ以降はめちゃくちゃでなんでだ...となりました。
