### PR TITLE
Show timestamps in the viewer's local timezone

### DIFF
--- a/client/RequestRecordComponent.tsx
+++ b/client/RequestRecordComponent.tsx
@@ -60,6 +60,7 @@ const RequestRecordComponent = forwardRef<
     linkToItem?: string;
   }
 >(({ record, linkToItem, ...props }, ref) => {
+  const localTimestamp = new Date(record.timestamp).toLocaleString(undefined, { timeZoneName: 'short', });
   return (
     <div className="requestRecord" {...props} ref={ref}>
       <h3 className="request">
@@ -68,10 +69,10 @@ const RequestRecordComponent = forwardRef<
       <div className="timestamp">
         {linkToItem ? (
           <Link to={`/bucket/${record.bucket}/${record.id}`}>
-            {record.timestamp}
+            {localTimestamp}
           </Link>
         ) : (
-          record.timestamp
+          localTimestamp
         )}
       </div>
       <Headers headers={record.request.headers} />


### PR DESCRIPTION
リクエストのtimestampについて`2025-03-19T09:56:36.214Z` と表示されているものを、ブラウザのlocaleに合わせて `2025/3/19 18:56:36 JST` のように表示されたらより便利だと思いました！そのパッチとなります！