### PR TITLE
Add real-time request monitoring with auto-refresh toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ The project uses a dual-build approach:
 2. Request data stored via storage adapter (OpenSearch or memory) with generated UUID
 3. Web interface at `/bucket/{bucket}` displays captured requests
 4. API endpoints serve request data from storage to React frontend
+5. Client polls for new requests every 5 seconds using `/api/bucket/{bucket}/record/?since={timestamp}` (auto-refresh can be toggled)
+6. New records are highlighted with a yellow background fade animation
 
 ## Code Style
 

--- a/client/Bucket.tsx
+++ b/client/Bucket.tsx
@@ -7,9 +7,12 @@ import RequestRecordComponent from './RequestRecordComponent';
 function Bucket({ ...props }: React.ComponentProps<'div'>) {
   const { bucket } = useParams<{ bucket: string }>();
   const [records, setRecords] = useState<
-    (RequestRecord & { loaded?: boolean })[]
+    (RequestRecord & { loaded?: boolean; isNew?: boolean })[]
   >([]);
   const [nextLink, setNextLink] = useState<string | null>(null);
+  const [isPollingEnabled, setIsPollingEnabled] = useState(false);
+  const [latestTimestamp, setLatestTimestamp] = useState<string | null>(null);
+  const [isTabVisible, setIsTabVisible] = useState(true);
   const loadedRef = useRef<HTMLDivElement>(null);
 
   const hasRecords = records != null && records.length > 0;
@@ -36,6 +39,14 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
 
         setRecords(items);
 
+        // Update latest timestamp for polling
+        if (loaded.length > 0 && from == null) {
+          setLatestTimestamp(loaded[0].timestamp);
+        } else if (loaded.length === 0 && from == null) {
+          // Initialize with current time if bucket is empty
+          setLatestTimestamp(new Date().toISOString());
+        }
+
         if (body.next != null) {
           setNextLink(body.next);
         } else {
@@ -56,9 +67,63 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
     }
   };
 
+  const pollNewRecords = async () => {
+    if (!bucket || !latestTimestamp || !isPollingEnabled) {
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/bucket/${bucket}/record/?since=${encodeURIComponent(latestTimestamp)}`,
+        {
+          method: 'GET',
+        }
+      );
+      if (res.ok) {
+        const body = await res.json();
+        const newRecords = body.records;
+
+        if (newRecords.length > 0) {
+          // Mark new records with isNew flag for highlighting
+          const markedRecords = newRecords.map((r: RequestRecord) => ({ ...r, isNew: true }));
+          setRecords([...markedRecords, ...records]);
+
+          // Update latest timestamp
+          setLatestTimestamp(newRecords[0].timestamp);
+        }
+      }
+    } catch (err) {
+      console.error('Polling error:', err);
+    }
+  };
+
   useEffect(() => {
     load();
   }, []);
+
+  // Track page visibility
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsTabVisible(!document.hidden);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  // Polling effect
+  useEffect(() => {
+    if (!isPollingEnabled || !latestTimestamp || !isTabVisible) {
+      return;
+    }
+
+    const intervalId = setInterval(pollNewRecords, 5000); // Poll every 5 seconds
+
+    return () => clearInterval(intervalId);
+  }, [bucket, latestTimestamp, isPollingEnabled, records, isTabVisible]);
 
   return (
     <div {...props}>
@@ -66,9 +131,20 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
         <Link to="/">request bucket</Link>: {bucket}
       </h1>
 
-      <button type="button" onClick={() => load()}>
-        Reload
-      </button>
+      <div className="controls">
+        <button type="button" onClick={() => load()}>
+          Refresh
+        </button>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={isPollingEnabled}
+            onChange={(e) => setIsPollingEnabled(e.target.checked)}
+          />
+          Auto-refresh
+        </label>
+      </div>
 
       {bucket && (
         <details open={!hasRecords}>

--- a/client/RequestRecordComponent.tsx
+++ b/client/RequestRecordComponent.tsx
@@ -56,13 +56,14 @@ function Body({
 const RequestRecordComponent = forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> & {
-    record: RequestRecord;
+    record: RequestRecord & { isNew?: boolean };
     linkToItem?: string;
   }
 >(({ record, linkToItem, ...props }, ref) => {
   const localTimestamp = new Date(record.timestamp).toLocaleString(undefined, { timeZoneName: 'short', });
+  const className = `requestRecord${record.isNew ? ' is-new' : ''}`;
   return (
-    <div className="requestRecord" {...props} ref={ref}>
+    <div className={className} {...props} ref={ref}>
       <h3 className="request">
         {record.request.method} {record.request.pathQuery}
       </h3>

--- a/client/index.scss
+++ b/client/index.scss
@@ -11,17 +11,39 @@
       text-decoration: none;
     }
   }
-  
+
   h2 {
     font-size: 1.4rem;
   }
-  
+
   h3 {
     font-size: 1.2rem;
   }
 
   pre {
     padding: 0.6rem 0.7rem;
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    button {
+      margin: 0;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      margin: 0;
+
+      input[type="checkbox"] {
+        margin: 0;
+      }
+    }
   }
 }
 
@@ -30,6 +52,10 @@
   padding: 0.75rem 0.75rem 0.2rem 0.75rem;
   border: 1px solid #e0e0e0;
   border-radius: 0.5rem;
+
+  &.is-new {
+    animation: highlight-fade 1s ease-out forwards;
+  }
 
   h2 {
     font-size: 1.2rem;
@@ -93,5 +119,14 @@
   .body {
     grid-column: 1 / -1;
     grid-row: 3 / 4;
+  }
+}
+
+@keyframes highlight-fade {
+  0% {
+    background-color: #fff9c4;
+  }
+  100% {
+    background-color: transparent;
   }
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -100,14 +100,16 @@ const onHookHandler: RouteHandlerMethod = async (req, reply) => {
 
 const onGetHookRecords: RouteHandlerMethodWithCustomRouteGeneric<{
   Params: { bucket: string };
-  Querystring: { from?: string };
+  Querystring: { from?: string; since?: string };
 }> = async (req, reply) => {
   const { bucket } = req.params;
   const from = req.query.from;
+  const since = req.query.since;
 
   try {
     const result = await storage.getRecords(bucket, {
       from,
+      since,
       limit: ITEMS_PER_PAGE,
     });
 
@@ -156,7 +158,7 @@ const setup = async (server: FastifyInstance) => {
       },
       handler: onHookHandler,
     })
-    .get<{ Params: { bucket: string }; Querystring: { from?: string } }>(
+    .get<{ Params: { bucket: string }; Querystring: { from?: string; since?: string } }>(
       '/api/bucket/:bucket/record/',
       onGetHookRecords,
     )

--- a/server/storage/interface.ts
+++ b/server/storage/interface.ts
@@ -14,6 +14,7 @@ export interface StorageAdapter {
     options?: {
       from?: string;
       limit?: number;
+      since?: string;
     }
   ): Promise<{
     records: RequestRecord[];

--- a/server/storage/opensearch.ts
+++ b/server/storage/opensearch.ts
@@ -35,9 +35,9 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
 
   async getRecords(
     bucket: string,
-    options: { from?: string; limit?: number } = {}
+    options: { from?: string; limit?: number; since?: string } = {}
   ): Promise<{ records: RequestRecord[]; next?: string }> {
-    const { from, limit = 5 } = options;
+    const { from, limit = 5, since } = options;
 
     const condition: Record<string, unknown>[] = [
       {
@@ -47,7 +47,18 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
       },
     ];
 
-    if (from != null && from.trim() !== '') {
+    // Filter by 'since' parameter if provided (for polling)
+    if (since != null && since.trim() !== '') {
+      condition.push({
+        range: {
+          timestamp: {
+            gt: since,
+          },
+        },
+      });
+    }
+    // Otherwise, filter by 'from' parameter if provided (for pagination)
+    else if (from != null && from.trim() !== '') {
       condition.push({
         range: {
           id: {


### PR DESCRIPTION
## Summary

Enable users to monitor incoming requests in real-time:
- Auto-refresh checkbox polls for new records every 5 seconds
- New records highlighted with subtle fade animation
- Polling pauses automatically when tab is inactive (saves bandwidth)

## Architecture Decision

Chose polling over Server-Sent Events (SSE) to keep the architecture simple and stateless. SSE would require additional components like Redis for pub/sub coordination across multiple server instances, increasing operational complexity. The polling approach works well with the existing stateless API and pluggable storage backends without introducing new dependencies.