### PR TITLE
Show full URL with origin in recording guide example

### DIFF
--- a/client/RecordingGuide.tsx
+++ b/client/RecordingGuide.tsx
@@ -5,6 +5,8 @@ function RecordingGuide({
   bucketId = 'sandbox',
   ...props
 }: React.ComponentProps<'div'> & { children?: ReactNode; bucketId?: string }) {
+  const currentOrigin = typeof window === 'undefined' ? '' : window.location.origin;
+
   return (
     <article {...props}>
       {children}
@@ -21,7 +23,7 @@ function RecordingGuide({
         &nbsp;&nbsp;&nbsp;&nbsp;-H 'Content-Type: application/json' \<br />
         &nbsp;&nbsp;&nbsp;&nbsp;-d '{'{'} "message": "Hello, world" {'}'}' \
         <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;/hook/{bucketId}/some/optional/path
+        &nbsp;&nbsp;&nbsp;&nbsp;{currentOrigin}/hook/{bucketId}/some/optional/path
       </pre>
 
       <p>You can use any HTTP method, such as GET, POST, PUT, or DELETE ...</p>


### PR DESCRIPTION
Currently guide using `curl` command doesn't work when user just copy and paste it, because guide doesn't include origin.
I think it would be even better if the guide worked with simple copy and paste.

In most cases, just adding `window.location.origin` is enough for guide. If we ever need to override it due to some reasons, we could add an option for that, but I do not think it is necessary right now, so this is a minimal change.

After this change is merged, it should work like this:

<img width="561" height="691" alt="with-this-change" src="https://github.com/user-attachments/assets/7e8ab6e8-e6ec-4221-a732-b7c40f6965e6" />
