### PR TITLE
fix: correct storage adapter tests to match timestamp-based pagination

### DIFF
--- a/server/storage/__tests__/memory.test.ts
+++ b/server/storage/__tests__/memory.test.ts
@@ -91,38 +91,39 @@ describe('MemoryStorageAdapter - Specific Implementation', () => {
 
   describe('pagination', () => {
     it('should provide correct pagination with next parameter', async () => {
-      const records = [];
-      for (let i = 1; i <= 6; i++) {
-        records.push(createSampleRecord(`test-id-${i}`, 'test-bucket'));
-      }
+      const baseTime = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const records = Array.from({ length: 6 }, (_, i) =>
+        createSampleRecord(
+          `test-id-${i + 1}`,
+          'test-bucket',
+          new Date(baseTime + i * 1000).toISOString(),
+        ),
+      );
 
-      // Store all records
       for (const record of records) {
         await adapter.store(record);
       }
 
-      // Get first page with limit 2
+      // Records are sorted descending: test-id-6 (newest) ... test-id-1 (oldest)
+
       const firstPage = await adapter.getRecords('test-bucket', { limit: 2 });
 
       expect(firstPage.records).toHaveLength(2);
       expect(firstPage.next).toBeDefined();
       expect(firstPage.next).toContain('from=');
 
-      // Get second page
-      const fromMatch = firstPage.next?.match(/from=([^&]+)/);
-      const from = fromMatch?.[1];
+      // Use the timestamp of the last record on this page as the cursor
+      const from1 = firstPage.records[firstPage.records.length - 1].timestamp;
 
       const secondPage = await adapter.getRecords('test-bucket', {
-        from,
+        from: from1,
         limit: 2,
       });
 
       expect(secondPage.records).toHaveLength(2);
       expect(secondPage.next).toBeDefined();
 
-      // Get third page
-      const fromMatch2 = secondPage.next?.match(/from=([^&]+)/);
-      const from2 = fromMatch2?.[1];
+      const from2 = secondPage.records[secondPage.records.length - 1].timestamp;
 
       const thirdPage = await adapter.getRecords('test-bucket', {
         from: from2,
@@ -130,16 +131,14 @@ describe('MemoryStorageAdapter - Specific Implementation', () => {
       });
 
       expect(thirdPage.records).toHaveLength(2);
-      expect(thirdPage.next).toBeUndefined(); // Last page
+      expect(thirdPage.next).toBeUndefined();
 
-      // Ensure no duplicates across pages
       const allIds = [
         ...firstPage.records.map((r) => r.id),
         ...secondPage.records.map((r) => r.id),
         ...thirdPage.records.map((r) => r.id),
       ];
-      const uniqueIds = new Set(allIds);
-      expect(uniqueIds.size).toBe(6);
+      expect(new Set(allIds).size).toBe(6);
     });
 
     it('should handle from parameter that does not exist', async () => {

--- a/server/storage/__tests__/opensearch.test.ts
+++ b/server/storage/__tests__/opensearch.test.ts
@@ -37,10 +37,12 @@ const mockIndex = vi.fn();
 const mockSearch = vi.fn();
 
 vi.mock('@opensearch-project/opensearch', () => ({
-  Client: vi.fn(() => ({
-    index: mockIndex,
-    search: mockSearch,
-  })),
+  Client: vi.fn(
+    class {
+      index = mockIndex;
+      search = mockSearch;
+    },
+  ),
 }));
 
 // Mock response helpers
@@ -329,7 +331,7 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
                 },
                 {
                   range: {
-                    id: {
+                    timestamp: {
                       lte: 'test-from-id',
                     },
                   },
@@ -366,15 +368,21 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
 
     it('should handle pagination when more records available', async () => {
       const bucket = 'test-bucket';
+      const baseTime = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mockTimestamps = Array.from({ length: 6 }, (_, i) =>
+        new Date(baseTime + i * 1000).toISOString(),
+      );
       const mockRecords = Array.from({ length: 6 }, (_, i) =>
-        createSampleRecord(`id-${i + 1}`, bucket),
+        createSampleRecord(`id-${i + 1}`, bucket, mockTimestamps[i]),
       );
       mockSearch.mockResolvedValue(createMockSearchResponse(mockRecords));
 
       const result = await adapter.getRecords(bucket, { limit: 5 });
 
       expect(result.records).toHaveLength(5);
-      expect(result.next).toBe(`/api/bucket/${bucket}/record/?from=id-6`);
+      expect(result.next).toBe(
+        `/api/bucket/${bucket}/record/?from=${mockTimestamps[5]}`,
+      );
     });
 
     it('should return empty array when OpenSearch returns error', async () => {


### PR DESCRIPTION
## Summary

- Fix `OpenSearchStorageAdapter` mock in tests: changed arrow function to `class` syntax so `new Client()` works correctly as a constructor
- Fix `from` parameter query assertion in OpenSearch tests: `range.id` → `range.timestamp` to match actual implementation
- Fix OpenSearch pagination `next` URL assertion: use timestamp-based cursor (matching `last.timestamp`) instead of record ID
- Fix `MemoryStorageAdapter` pagination test: use each page's last record timestamp as the `from` cursor instead of extracting an ID from the `next` URL (the implementation compares `record.timestamp === from`)

## Test plan

- [x] `npm test` passes all 85 tests