### PR TITLE
fix: enable Biome VCS integration to respect .gitignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
-    "enabled": false,
+    "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": false
+    "useIgnoreFile": true
   },
   "files": {
     "ignoreUnknown": false,


### PR DESCRIPTION
## Summary

- Enable Biome's VCS integration (`vcs.enabled: true`) so it can read the `.gitignore` file
- Set `vcs.useIgnoreFile: true` to exclude paths listed in `.gitignore` (e.g. `dist/`) from linting and formatting checks

## Test plan

- [x] Run `npm run check` and confirm `dist/` is no longer reported