### PR TITLE
feat: add version footer with app version and git commit hash

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -16,19 +16,42 @@ function NotFound() {
 
 function App() {
   return (
-    <main className="container">
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Top />} />
-          <Route path="/bucket/:bucket" element={<Bucket />} />
-          <Route
-            path="/bucket/:bucket/:recordId"
-            element={<RequestRecordView />}
-          />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </main>
+    <>
+      <main className="container">
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Top />} />
+            <Route path="/bucket/:bucket" element={<Bucket />} />
+            <Route
+              path="/bucket/:bucket/:recordId"
+              element={<RequestRecordView />}
+            />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </main>
+      <footer className="container app-footer">
+        <small>
+          request-bucket{' '}
+          <a
+            href={`https://github.com/dayflower/request-bucket/releases/tag/v${__APP_VERSION__}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            v{__APP_VERSION__}
+          </a>{' '}
+          (
+          <a
+            href={`https://github.com/dayflower/request-bucket/commit/${__GIT_COMMIT__}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {__GIT_COMMIT__.slice(0, 7)}
+          </a>
+          )
+        </small>
+      </footer>
+    </>
   );
 }
 

--- a/client/index.scss
+++ b/client/index.scss
@@ -130,3 +130,13 @@
     background-color: transparent;
   }
 }
+
+.app-footer {
+  text-align: left;
+  padding: 0.5rem 0 1.5rem;
+  color: var(--pico-muted-color);
+
+  small {
+    font-size: 0.75rem;
+  }
+}

--- a/client/vite-env.d.ts
+++ b/client/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __GIT_COMMIT__: string;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,7 +18,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
   "include": ["vite.config.ts", "server/**/*", "lib/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,15 @@
+import { execSync } from 'node:child_process';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import pkg from './package.json' with { type: 'json' };
+
+function getGitCommit(): string {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,5 +19,9 @@ export default defineConfig({
   base: '/',
   build: {
     outDir: '../dist/public',
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __GIT_COMMIT__: JSON.stringify(getGitCommit()),
   },
 });


### PR DESCRIPTION
## Summary

- Add a footer to every page showing the app version and git commit hash
- Version number links to the GitHub Releases page for that tag
- Commit hash links to the GitHub commit page (full hash in URL, 7-char display)
- Footer width matches the main content area
- Uses Pico CSS `--pico-muted-color` variable for automatic light/dark theme support

## Implementation

- `vite.config.ts`: Inject `__APP_VERSION__` (from `package.json`) and `__GIT_COMMIT__` (full hash via `git rev-parse HEAD`) as build-time constants using Vite's `define`
- `tsconfig.node.json`: Add `resolveJsonModule: true` to support JSON import with `with { type: 'json' }` syntax (Node.js 22+)
- `client/vite-env.d.ts`: Add type declarations for the two injected globals
- `client/App.tsx`: Add `<footer>` element as sibling of `<main>`
- `client/index.scss`: Add `.app-footer` styles

## Test plan

- [x] Run `npm run dev` and verify footer appears on `/`, `/bucket/:bucket`, and `/bucket/:bucket/:recordId`
- [x] Confirm version link opens the correct GitHub Releases tag page in a new tab
- [x] Confirm commit hash link opens the correct GitHub commit page in a new tab
- [x] Run `npm run build:client` and confirm no TypeScript errors