### PR TITLE
chore: upgrade Node.js to v24 and Debian to trixie (13)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ Dockerfile
 **/.env.*
 
 **/node_modules/
-**/.git
+
+# .git is intentionally included to allow vite.config.ts to embed the git commit hash at build time
+# **/.git
 
 **/.vscode/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:22-bookworm AS builder
+FROM node:24-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN npm ci && npm run build:client && npm run build:server
 
 
 
-FROM node:22-bookworm AS running-env
+FROM node:24-bookworm-slim AS running-env
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN npm ci --production
 
 
 
-FROM gcr.io/distroless/nodejs22-debian12:nonroot AS runner
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM node:24-trixie-slim AS builder
 
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
 WORKDIR /app
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:24-bookworm-slim AS builder
+FROM node:24-trixie-slim AS builder
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN npm ci && npm run build:client && npm run build:server
 
 
 
-FROM node:24-bookworm-slim AS running-env
+FROM node:24-trixie-slim AS running-env
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN npm ci --production
 
 
 
-FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runner
+FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runner
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
-        "@types/node": "^22.19.17",
+        "@types/node": "^24",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^6.0.1",
@@ -37,7 +37,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1669,13 +1669,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -4182,9 +4182,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "tsx watch --env-file=.env --ignore=./vite.config.ts* --ignore=./client --clear-screen=false server/dev.ts",
     "prod": "tsx --env-file=.env server/prod.ts",
     "build:client": "tsc --noEmit -p tsconfig.app.json && vite build --emptyOutDir",
-    "build:server": "tsc --noEmit && esbuild --bundle --external:./node_modules/* --format=esm --platform=node --target=es2022,node20 server/prod.ts --outfile=dist/index.mjs",
+    "build:server": "tsc --noEmit && esbuild --bundle --external:./node_modules/* --format=esm --platform=node --target=es2022,node24 server/prod.ts --outfile=dist/index.mjs",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
@@ -31,7 +31,7 @@
     "clean": "rm -rf dist"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "dependencies": {
     "@fastify/static": "^9.1.3",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
-    "@types/node": "^22.19.17",
+    "@types/node": "^24",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.1",


### PR DESCRIPTION
## Summary

- Upgrade Node.js from v22 to v24 (`package.json`, `ci.yml`, `Dockerfile`)
- Switch Docker base images from `node:22-bookworm` to `node:24-trixie-slim` (fewer vulnerabilities: 1 critical + 14 high → 1 high)
- Switch distroless runner from `nodejs22-debian12` to `nodejs24-debian13`
- Install `git` in builder stage and include `.git` in build context so the version footer correctly embeds the git commit hash (instead of falling back to `unknown`)
- Update `@types/node` to `^24`
- Update esbuild target to `node24`

## Test plan

- [x] `npm run check` passes
- [x] `npm run typecheck` passes
- [x] `npm test -- --run` passes (85 tests)
- [x] `docker build` succeeds without warnings