### PR TITLE
feat: set dynamic page title based on current route

### DIFF
--- a/client/Bucket.tsx
+++ b/client/Bucket.tsx
@@ -104,6 +104,15 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
     load();
   }, [load]);
 
+  useEffect(() => {
+    if (bucket) {
+      document.title = `request-bucket: ${bucket}`;
+    }
+    return () => {
+      document.title = 'request-bucket';
+    };
+  }, [bucket]);
+
   // Track page visibility
   useEffect(() => {
     const handleVisibilityChange = () => {

--- a/client/RequestRecordView.tsx
+++ b/client/RequestRecordView.tsx
@@ -32,6 +32,20 @@ function RequestRecordView({ ...props }: React.ComponentProps<'div'>) {
     load();
   }, [load]);
 
+  useEffect(() => {
+    if (bucket) {
+      const timestamp = record
+        ? new Date(record.timestamp).toLocaleString()
+        : null;
+      document.title = timestamp
+        ? `request-bucket: ${bucket}: ${timestamp}`
+        : `request-bucket: ${bucket}`;
+    }
+    return () => {
+      document.title = 'request-bucket';
+    };
+  }, [bucket, record]);
+
   return (
     <div {...props}>
       <h1>


### PR DESCRIPTION
## Summary

- Bucket page (`/bucket/:bucket`): title becomes `request-bucket: {bucket}`
- Record detail page (`/bucket/:bucket/:recordId`): title becomes `request-bucket: {bucket}: {timestamp}` once the record loads (falls back to `request-bucket: {bucket}` while loading)
- Navigating away resets the title to `request-bucket`

## Test plan

- [x] `/bucket/sandbox` → tab shows `request-bucket: sandbox`
- [x] `/bucket/sandbox/{id}` → tab initially shows `request-bucket: sandbox`, then updates to `request-bucket: sandbox: {localTimestamp}` after record loads
- [x] Navigate back to `/` → tab resets to `request-bucket`