### PR TITLE
fix: use timestamp instead of id in memory storage next URL for pagination

### DIFF
--- a/server/storage/__tests__/memory.test.ts
+++ b/server/storage/__tests__/memory.test.ts
@@ -164,7 +164,10 @@ describe('MemoryStorageAdapter - Specific Implementation', () => {
       const from = decodeURIComponent(encodedFrom as string);
       expect(new Date(from).toString()).not.toBe('Invalid Date');
 
-      const secondPage = await adapter.getRecords('test-bucket', { from, limit: 2 });
+      const secondPage = await adapter.getRecords('test-bucket', {
+        from,
+        limit: 2,
+      });
       expect(secondPage.records).toHaveLength(2);
 
       const allIds = [

--- a/server/storage/__tests__/memory.test.ts
+++ b/server/storage/__tests__/memory.test.ts
@@ -141,6 +141,39 @@ describe('MemoryStorageAdapter - Specific Implementation', () => {
       expect(new Set(allIds).size).toBe(6);
     });
 
+    it('should include a valid decodable timestamp in next URL', async () => {
+      const baseTime = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const records = Array.from({ length: 4 }, (_, i) =>
+        createSampleRecord(
+          `test-id-${i + 1}`,
+          'test-bucket',
+          new Date(baseTime + i * 1000).toISOString(),
+        ),
+      );
+      for (const record of records) {
+        await adapter.store(record);
+      }
+
+      const firstPage = await adapter.getRecords('test-bucket', { limit: 2 });
+      expect(firstPage.next).toBeDefined();
+
+      const fromMatch = firstPage.next?.match(/from=([^&]+)/);
+      const encodedFrom = fromMatch?.[1];
+      expect(encodedFrom).toBeDefined();
+
+      const from = decodeURIComponent(encodedFrom as string);
+      expect(new Date(from).toString()).not.toBe('Invalid Date');
+
+      const secondPage = await adapter.getRecords('test-bucket', { from, limit: 2 });
+      expect(secondPage.records).toHaveLength(2);
+
+      const allIds = [
+        ...firstPage.records.map((r) => r.id),
+        ...secondPage.records.map((r) => r.id),
+      ];
+      expect(new Set(allIds).size).toBe(4);
+    });
+
     it('should handle from parameter that does not exist', async () => {
       const record = createSampleRecord('test-id-1', 'test-bucket');
       await adapter.store(record);

--- a/server/storage/__tests__/opensearch.test.ts
+++ b/server/storage/__tests__/opensearch.test.ts
@@ -139,22 +139,20 @@ createStorageInterfaceTests('OpenSearchStorageAdapter', () => {
             new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
         );
 
-        const limit = body.size ? body.size - 1 : 5; // Adjust for pagination detection
         const from = filterConditions.find(
           (f): f is RangeCondition =>
             'range' in f && f.range?.timestamp !== undefined,
         )?.range?.timestamp?.lte;
         let filteredRecords = bucketRecords;
         if (from) {
-          const fromIndex = bucketRecords.findIndex(
-            (r) => r.timestamp === from,
+          filteredRecords = bucketRecords.filter(
+            (r) =>
+              new Date(r.timestamp).getTime() <= new Date(from).getTime(),
           );
-          if (fromIndex >= 0) {
-            filteredRecords = bucketRecords.slice(fromIndex + 1);
-          }
         }
 
-        const paginatedRecords = filteredRecords.slice(0, limit);
+        // Return up to body.size records so the adapter can detect pagination
+        const paginatedRecords = filteredRecords.slice(0, body.size ?? 6);
         return createMockSearchResponse(paginatedRecords);
       }
 

--- a/server/storage/__tests__/opensearch.test.ts
+++ b/server/storage/__tests__/opensearch.test.ts
@@ -146,8 +146,7 @@ createStorageInterfaceTests('OpenSearchStorageAdapter', () => {
         let filteredRecords = bucketRecords;
         if (from) {
           filteredRecords = bucketRecords.filter(
-            (r) =>
-              new Date(r.timestamp).getTime() <= new Date(from).getTime(),
+            (r) => new Date(r.timestamp).getTime() <= new Date(from).getTime(),
           );
         }
 

--- a/server/storage/__tests__/shared/storage-interface.test.ts
+++ b/server/storage/__tests__/shared/storage-interface.test.ts
@@ -97,28 +97,35 @@ export function createStorageInterfaceTests(
       });
 
       it('should handle pagination with from parameter', async () => {
-        const record1 = createSampleRecord('test-id-1', 'test-bucket');
-        const record2 = createSampleRecord('test-id-2', 'test-bucket');
+        const baseTime = new Date('2026-01-01T00:00:00.000Z').getTime();
+        const record1 = createSampleRecord(
+          'test-id-1',
+          'test-bucket',
+          new Date(baseTime).toISOString(),
+        );
+        const record2 = createSampleRecord(
+          'test-id-2',
+          'test-bucket',
+          new Date(baseTime + 1000).toISOString(),
+        );
 
         await adapter.store(record1);
         await adapter.store(record2);
 
         const firstPage = await adapter.getRecords('test-bucket', { limit: 1 });
         expect(firstPage.records).toHaveLength(1);
+        expect(firstPage.next).toBeDefined();
 
-        if (firstPage.next) {
-          // Extract from parameter from next URL
-          const fromMatch = firstPage.next.match(/from=([^&]+)/);
-          const from = fromMatch ? fromMatch[1] : undefined;
+        const fromMatch = firstPage.next?.match(/from=([^&]+)/);
+        const from = fromMatch ? decodeURIComponent(fromMatch[1]) : undefined;
+        expect(from).toBeDefined();
 
-          if (from) {
-            const secondPage = await adapter.getRecords('test-bucket', {
-              from,
-              limit: 1,
-            });
-            expect(secondPage.records).toHaveLength(1);
-          }
-        }
+        const secondPage = await adapter.getRecords('test-bucket', {
+          from,
+          limit: 1,
+        });
+        expect(secondPage.records).toHaveLength(1);
+        expect(secondPage.records[0].id).not.toBe(firstPage.records[0].id);
       });
     });
 

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -64,7 +64,7 @@ export class MemoryStorageAdapter implements StorageAdapter {
     if (paginatedRecords.length > limit) {
       const lastRecord = records[records.length - 1];
       if (lastRecord?.id) {
-        next = `/api/bucket/${bucket}/record/?from=${lastRecord.id}`;
+        next = `/api/bucket/${bucket}/record/?from=${encodeURIComponent(lastRecord.timestamp)}`;
       }
     }
 


### PR DESCRIPTION
## Summary

- `MemoryStorageAdapter.getRecords` was generating the `next` URL with `lastRecord.id`, but the `from` parameter filter compared against `record.timestamp` — causing `findIndex` to always return `-1` and pagination to restart from the newest records every time "Load more" was clicked
- Fixed by using `encodeURIComponent(lastRecord.timestamp)` in the `next` URL, consistent with how the `since` parameter is encoded on the client side
- Only affected `STORAGE_TYPE=memory` (default); OpenSearch storage was already correct

## Test plan

- [ ] Updated shared `storage-interface.test.ts`: adds `decodeURIComponent` when extracting `from` from the `next` URL (simulating the HTTP layer), and asserts the second page returns a different record than the first
- [ ] Added test in `memory.test.ts`: validates the `next` URL contains a decodable ISO timestamp (not an ID), and that following it yields non-overlapping records across pages
- [ ] Fixed OpenSearch shared-suite mock: was returning `limit` records instead of `limit+1`, preventing pagination detection; also corrected `from` filtering to use `timestamp <= from` matching OpenSearch's `lte` range query
- [ ] All 86 tests pass