### PR TITLE
chore: bump version to v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "request-bucket",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "request-bucket",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^9.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "request-bucket",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "author": "dayflower",
   "repository": {


### PR DESCRIPTION
Bumps version to `v0.7.0`. Merging this PR will automatically create the git tag, build Docker images, and publish a GitHub Release.