### PR TITLE
feat: add access logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ The index mapping definition is available in [`opensearch/bucket-index.json`](op
   - Example: `x-forwarded-,cf-`
 
 
+## Logging
+
+Access logs are printed to stdout for all requests:
+
+```
+[2024-01-01T12:00:00.000Z] POST /hook/my-bucket 200 12ms
+[2024-01-01T12:00:00.001Z] GET /api/bucket/my-bucket/record/ 200 3ms
+```
+
+> **Note:** In development mode, SPA routes (`/`, `/bucket/*`, static assets) are not logged due to Bun's HTML module constraints.
+
 ## License
 
 MIT

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,14 +17,31 @@ const getRecord = createGetRecordHandler(storage);
 // with HMR. In prod, we serve the pre-built artifacts under dist/public/.
 const spaRoute = dev
   ? (await import('../client/index.html')).default
-  : staticHandler;
+  : withLogging(staticHandler);
+
+function withLogging<T extends Request>(
+  handler: (req: T) => Promise<Response>,
+): (req: T) => Promise<Response> {
+  return async (req: T): Promise<Response> => {
+    const start = performance.now();
+    const response = await handler(req);
+    const elapsed = (performance.now() - start).toFixed(0);
+    const url = new URL(req.url);
+    const path = url.pathname + url.search;
+    const ts = new Date().toISOString();
+    console.log(
+      `[${ts}] ${req.method} ${path} ${response.status} ${elapsed}ms`,
+    );
+    return response;
+  };
+}
 
 const server = serve({
   port,
   routes: {
-    '/api/bucket/:bucket/record/': getRecords,
-    '/api/bucket/:bucket/record/:id': getRecord,
-    '/hook/*': hookHandler,
+    '/api/bucket/:bucket/record/': withLogging(getRecords),
+    '/api/bucket/:bucket/record/:id': withLogging(getRecord),
+    '/hook/*': withLogging(hookHandler),
     '/*': spaRoute,
   },
   development: dev && { hmr: true, console: true },


### PR DESCRIPTION
## Summary

- Add `withLogging` wrapper to log all hook, API, and (in production) SPA/static requests to stdout
- Log format: `[ISO timestamp] METHOD path status Xms`
- Document logging behavior in README

## Note

In development mode, SPA routes are handled by Bun's HTML module which cannot be wrapped as a function, so those requests are not logged.