### PR TITLE
refactor: deduplicate filterHeaders and createSampleRecord across storage adapters

### DIFF
--- a/server/storage/__tests__/helpers.ts
+++ b/server/storage/__tests__/helpers.ts
@@ -1,0 +1,29 @@
+import type { RequestRecord } from '../../../common/types';
+
+export const createSampleRecord = (
+  id: string,
+  bucket: string,
+  timestamp?: string,
+  headers?: Record<string, string>,
+): RequestRecord => ({
+  id,
+  timestamp: timestamp || new Date().toISOString(),
+  bucket,
+  request: {
+    method: 'POST',
+    protocol: 'http',
+    host: 'localhost',
+    port: 3000,
+    pathQuery: `/hook/${bucket}/test`,
+    path: `/hook/${bucket}/test`,
+    args: '/test',
+    queryString: '',
+    query: {},
+    headers: headers || {
+      'content-type': 'application/json',
+      'user-agent': 'test-agent',
+    },
+    bodyRaw: '{"test": "data"}',
+    bodyJson: { test: 'data' },
+  },
+});

--- a/server/storage/__tests__/memory.test.ts
+++ b/server/storage/__tests__/memory.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import type { RequestRecord } from '../../../common/types';
 import { MemoryStorageAdapter } from '../memory';
+import { createSampleRecord } from './helpers';
 import { createStorageInterfaceTests } from './shared/storage-interface.test';
 
 // Run shared interface tests
@@ -11,34 +11,6 @@ createStorageInterfaceTests(
 
 describe('MemoryStorageAdapter - Specific Implementation', () => {
   let adapter: MemoryStorageAdapter;
-
-  const createSampleRecord = (
-    id: string,
-    bucket: string,
-    timestamp?: string,
-    headers?: Record<string, string>,
-  ): RequestRecord => ({
-    id,
-    timestamp: timestamp || new Date().toISOString(),
-    bucket,
-    request: {
-      method: 'POST',
-      protocol: 'http',
-      host: 'localhost',
-      port: 3000,
-      pathQuery: `/hook/${bucket}/test`,
-      path: `/hook/${bucket}/test`,
-      args: '/test',
-      queryString: '',
-      query: {},
-      headers: headers || {
-        'content-type': 'application/json',
-        'user-agent': 'test-agent',
-      },
-      bodyRaw: '{"test": "data"}',
-      bodyJson: { test: 'data' },
-    },
-  });
 
   beforeEach(() => {
     adapter = new MemoryStorageAdapter();

--- a/server/storage/__tests__/opensearch.test.ts
+++ b/server/storage/__tests__/opensearch.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { RequestRecord } from '../../../common/types';
 import type { OpenSearchStorageAdapter as OpenSearchStorageAdapterType } from '../opensearch';
+import { createSampleRecord } from './helpers';
 import { createStorageInterfaceTests } from './shared/storage-interface.test';
 
 interface TermCondition {
@@ -173,34 +174,6 @@ createStorageInterfaceTests('OpenSearchStorageAdapter', () => {
 
 describe('OpenSearchStorageAdapter - Specific Implementation', () => {
   let adapter: OpenSearchStorageAdapterType;
-
-  const createSampleRecord = (
-    id: string,
-    bucket: string,
-    timestamp?: string,
-    headers?: Record<string, string>,
-  ): RequestRecord => ({
-    id,
-    timestamp: timestamp || new Date().toISOString(),
-    bucket,
-    request: {
-      method: 'POST',
-      protocol: 'http',
-      host: 'localhost',
-      port: 3000,
-      pathQuery: `/hook/${bucket}/test`,
-      path: `/hook/${bucket}/test`,
-      args: '/test',
-      queryString: '',
-      query: {},
-      headers: headers || {
-        'content-type': 'application/json',
-        'user-agent': 'test-agent',
-      },
-      bodyRaw: '{"test": "data"}',
-      bodyJson: { test: 'data' },
-    },
-  });
 
   beforeEach(() => {
     mockIndex.mockReset();

--- a/server/storage/__tests__/shared/storage-interface.test.ts
+++ b/server/storage/__tests__/shared/storage-interface.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import type { RequestRecord } from '../../../../common/types';
 import type { StorageAdapter } from '../../interface';
+import { createSampleRecord } from '../helpers';
 
 /**
  * Shared test suite for storage adapters to ensure they conform to the StorageAdapter interface
@@ -11,33 +11,6 @@ export function createStorageInterfaceTests(
 ) {
   describe(`${name} - StorageAdapter Interface`, () => {
     let adapter: StorageAdapter;
-
-    const createSampleRecord = (
-      id: string,
-      bucket: string,
-      timestamp?: string,
-    ): RequestRecord => ({
-      id,
-      timestamp: timestamp || new Date().toISOString(),
-      bucket,
-      request: {
-        method: 'POST',
-        protocol: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathQuery: `/hook/${bucket}/test`,
-        path: `/hook/${bucket}/test`,
-        args: '/test',
-        queryString: '',
-        query: {},
-        headers: {
-          'content-type': 'application/json',
-          'user-agent': 'test-agent',
-        },
-        bodyRaw: '{"test": "data"}',
-        bodyJson: { test: 'data' },
-      },
-    });
 
     beforeEach(() => {
       adapter = createAdapter();

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -1,5 +1,6 @@
 import type { RequestRecord } from '../../common/types';
 import type { StorageAdapter } from './interface';
+import { filterHeaders } from './utils';
 
 export class MemoryStorageAdapter implements StorageAdapter {
   private records: Map<string, RequestRecord[]> = new Map();
@@ -57,7 +58,7 @@ export class MemoryStorageAdapter implements StorageAdapter {
     const paginatedRecords = filteredRecords.slice(0, limit + 1);
     const records = paginatedRecords
       .slice(0, limit)
-      .map((record) => this.filterHeaders(record));
+      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
 
     // Check if there are more records
     let next: string | undefined;
@@ -75,22 +76,7 @@ export class MemoryStorageAdapter implements StorageAdapter {
     const bucketRecords = this.records.get(bucket) || [];
     const record = bucketRecords.find((r) => r.id === id);
 
-    return record ? this.filterHeaders(record) : null;
-  }
-
-  private filterHeaders(item: RequestRecord): RequestRecord {
-    if (this.ignoreHeaderPrefixes.length === 0) {
-      return item;
-    }
-
-    const headers = Object.fromEntries(
-      Object.entries(item.request.headers).filter(
-        ([key]) =>
-          !this.ignoreHeaderPrefixes.some((prefix) => key.startsWith(prefix)),
-      ),
-    );
-
-    return { ...item, request: { ...item.request, headers } };
+    return record ? filterHeaders(record, this.ignoreHeaderPrefixes) : null;
   }
 
   // Utility method for debugging/monitoring

--- a/server/storage/opensearch.ts
+++ b/server/storage/opensearch.ts
@@ -1,6 +1,7 @@
 import { Client } from '@opensearch-project/opensearch';
 import type { RequestRecord } from '../../common/types';
 import type { StorageAdapter } from './interface';
+import { filterHeaders } from './utils';
 
 interface SearchHit<T> {
   _id: string;
@@ -104,7 +105,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
     const hits = (res.body.hits.hits as SearchHit<RequestRecord>[])
       .filter((hit) => hit._source != null)
       .map((hit) => ({ ...hit._source, _id: hit._id }) as RequestRecord)
-      .map((record) => this.filterHeaders(record));
+      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
 
     if (hits.length > limit) {
       const last = hits.pop();
@@ -156,23 +157,8 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
     const records = (res.body.hits.hits as SearchHit<RequestRecord>[])
       .filter((hit) => hit._source != null)
       .map((hit) => ({ ...hit._source, _id: hit._id }) as RequestRecord)
-      .map((record) => this.filterHeaders(record));
+      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
 
     return records.length > 0 ? records[0] : null;
-  }
-
-  private filterHeaders(item: RequestRecord): RequestRecord {
-    if (this.ignoreHeaderPrefixes.length === 0) {
-      return item;
-    }
-
-    const headers = Object.fromEntries(
-      Object.entries(item.request.headers).filter(
-        ([key]) =>
-          !this.ignoreHeaderPrefixes.some((prefix) => key.startsWith(prefix)),
-      ),
-    );
-
-    return { ...item, request: { ...item.request, headers } };
   }
 }

--- a/server/storage/utils.ts
+++ b/server/storage/utils.ts
@@ -1,0 +1,18 @@
+import type { RequestRecord } from '../../common/types';
+
+export function filterHeaders(
+  item: RequestRecord,
+  ignoreHeaderPrefixes: string[],
+): RequestRecord {
+  if (ignoreHeaderPrefixes.length === 0) {
+    return item;
+  }
+
+  const headers = Object.fromEntries(
+    Object.entries(item.request.headers).filter(
+      ([key]) => !ignoreHeaderPrefixes.some((prefix) => key.startsWith(prefix)),
+    ),
+  );
+
+  return { ...item, request: { ...item.request, headers } };
+}


### PR DESCRIPTION
Related to #34

## Summary

- Extract `filterHeaders` from `MemoryStorageAdapter` and `OpenSearchStorageAdapter` into a shared `server/storage/utils.ts` module
- Extract `createSampleRecord` test fixture from three test files into a shared `server/storage/__tests__/helpers.ts` module

## Changes

- **New**: `server/storage/utils.ts` — standalone `filterHeaders(item, ignoreHeaderPrefixes)` function
- **New**: `server/storage/__tests__/helpers.ts` — shared `createSampleRecord` with optional `headers` parameter (superset of the previous simpler version)
- **Edited**: `server/storage/memory.ts`, `server/storage/opensearch.ts` — removed private `filterHeaders` methods, now import and call the shared utility
- **Edited**: `server/storage/__tests__/shared/storage-interface.test.ts`, `memory.test.ts`, `opensearch.test.ts` — removed local `createSampleRecord` definitions, now import from shared helpers

## Test plan

- [ ] `bun test` — all 86 tests pass
- [ ] `bun run typecheck` — no type errors
- [ ] `bun run check` — Biome reports no issues