### PR TITLE
fix: distinguish storage errors (500) from not-found (404) in read API

### DIFF
--- a/client/Bucket.tsx
+++ b/client/Bucket.tsx
@@ -13,6 +13,7 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
   const [isPollingEnabled, setIsPollingEnabled] = useState(false);
   const [latestTimestamp, setLatestTimestamp] = useState<string | null>(null);
   const [isTabVisible, setIsTabVisible] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const loadedRef = useRef<HTMLDivElement>(null);
 
   const hasRecords = records != null && records.length > 0;
@@ -30,6 +31,7 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
           method: 'GET',
         });
         if (res.ok) {
+          setError(null);
           const body = await res.json();
 
           const loaded = body.records;
@@ -61,9 +63,12 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
               });
             }, 100);
           }
+        } else {
+          setError('Failed to load records from storage.');
         }
       } catch (err) {
         console.error(err);
+        setError('Failed to load records from storage.');
       }
     },
     [bucket],
@@ -82,6 +87,7 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
         },
       );
       if (res.ok) {
+        setError(null);
         const body = await res.json();
         const newRecords = body.records;
 
@@ -94,9 +100,12 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
 
           setLatestTimestamp(newRecords[0].timestamp);
         }
+      } else {
+        setError('Auto-refresh failed: storage error.');
       }
     } catch (err) {
       console.error('Polling error:', err);
+      setError('Auto-refresh failed: storage error.');
     }
   }, [bucket, latestTimestamp, isPollingEnabled]);
 
@@ -142,6 +151,8 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
       <h1>
         <Link to="/">request bucket</Link>: {bucket}
       </h1>
+
+      {error && <p className="error-message">{error}</p>}
 
       <div className="controls">
         <button type="button" onClick={() => load()}>

--- a/client/RequestRecordView.tsx
+++ b/client/RequestRecordView.tsx
@@ -9,6 +9,7 @@ function RequestRecordView({ ...props }: React.ComponentProps<'div'>) {
     recordId: string;
   }>();
   const [record, setRecord] = useState<RequestRecord>();
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (bucket == null || recordId == null) {
@@ -20,11 +21,17 @@ function RequestRecordView({ ...props }: React.ComponentProps<'div'>) {
         method: 'GET',
       });
       if (res.ok) {
+        setError(null);
         const record = await res.json();
         setRecord(record);
+      } else if (res.status === 404) {
+        setError('Record not found.');
+      } else {
+        setError('Failed to load record from storage.');
       }
     } catch (err) {
       console.error(err);
+      setError('Failed to load record from storage.');
     }
   }, [bucket, recordId]);
 
@@ -54,6 +61,8 @@ function RequestRecordView({ ...props }: React.ComponentProps<'div'>) {
       </h1>
 
       <h2>Request</h2>
+
+      {error && <p className="error-message">{error}</p>}
 
       {record && (
         <RequestRecordComponent

--- a/client/style.css
+++ b/client/style.css
@@ -278,6 +278,16 @@ td {
   }
 }
 
+/* Error Message */
+.error-message {
+  padding: 0.75rem 1rem;
+  background-color: #fef2f2;
+  border: 1px solid #fca5a5;
+  border-radius: var(--border-radius);
+  color: #b91c1c;
+  margin-bottom: 1rem;
+}
+
 /* Request Record */
 .requestRecord {
   display: grid;

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test';
+import { createSampleRecord } from '../../storage/__tests__/helpers';
+import type { StorageAdapter } from '../../storage/interface';
+import { createGetRecordHandler, createGetRecordsHandler } from '../api';
+
+const makeRecordsRequest = (bucket: string, query = '') =>
+  Object.assign(
+    new Request(`http://localhost/api/bucket/${bucket}/record/${query}`),
+    {
+      params: { bucket },
+    },
+  ) as unknown as Bun.BunRequest<'/api/bucket/:bucket/record/'>;
+
+const makeRecordRequest = (bucket: string, id: string) =>
+  Object.assign(
+    new Request(`http://localhost/api/bucket/${bucket}/record/${id}`),
+    {
+      params: { bucket, id },
+    },
+  ) as unknown as Bun.BunRequest<'/api/bucket/:bucket/record/:id'>;
+
+const mockStorage = (overrides: Partial<StorageAdapter>): StorageAdapter => ({
+  store: async () => {},
+  getRecords: async () => ({ records: [] }),
+  getRecord: async () => null,
+  ...overrides,
+});
+
+describe('createGetRecordsHandler', () => {
+  it('returns 200 with records on success', async () => {
+    const record = createSampleRecord('id-1', 'test-bucket');
+    const storage = mockStorage({
+      getRecords: async () => ({ records: [record] }),
+    });
+
+    const handler = createGetRecordsHandler(storage);
+    const res = await handler(makeRecordsRequest('test-bucket'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0].id).toBe('id-1');
+  });
+
+  it('returns 500 when storage throws', async () => {
+    const storage = mockStorage({
+      getRecords: async () => {
+        throw new Error('OpenSearch error: 503');
+      },
+    });
+
+    const handler = createGetRecordsHandler(storage);
+    const res = await handler(makeRecordsRequest('test-bucket'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.message).toBe('Internal server error');
+  });
+});
+
+describe('createGetRecordHandler', () => {
+  it('returns 200 with record on success', async () => {
+    const record = createSampleRecord('id-1', 'test-bucket');
+    const storage = mockStorage({
+      getRecord: async () => record,
+    });
+
+    const handler = createGetRecordHandler(storage);
+    const res = await handler(makeRecordRequest('test-bucket', 'id-1'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('id-1');
+  });
+
+  it('returns 404 when record is not found', async () => {
+    const storage = mockStorage({
+      getRecord: async () => null,
+    });
+
+    const handler = createGetRecordHandler(storage);
+    const res = await handler(makeRecordRequest('test-bucket', 'missing'));
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.message).toBe('Record not found');
+  });
+
+  it('returns 500 when storage throws', async () => {
+    const storage = mockStorage({
+      getRecord: async () => {
+        throw new Error('OpenSearch error: 503');
+      },
+    });
+
+    const handler = createGetRecordHandler(storage);
+    const res = await handler(makeRecordRequest('test-bucket', 'id-1'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.message).toBe('Internal server error');
+  });
+});

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -20,7 +20,10 @@ export const createGetRecordsHandler = (storage: StorageAdapter) => {
       return Response.json(result);
     } catch (error) {
       console.error('Failed to get records:', error);
-      return Response.json({ records: [] });
+      return Response.json(
+        { message: 'Internal server error' },
+        { status: 500 },
+      );
     }
   };
 };
@@ -39,7 +42,10 @@ export const createGetRecordHandler = (storage: StorageAdapter) => {
       return Response.json(record);
     } catch (error) {
       console.error('Failed to get record:', error);
-      return Response.json({ message: 'Record not found' }, { status: 404 });
+      return Response.json(
+        { message: 'Internal server error' },
+        { status: 500 },
+      );
     }
   };
 };

--- a/server/storage/__tests__/opensearch.test.ts
+++ b/server/storage/__tests__/opensearch.test.ts
@@ -360,13 +360,13 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
       );
     });
 
-    it('should return empty array when OpenSearch returns error', async () => {
+    it('should throw when OpenSearch returns error', async () => {
       const bucket = 'test-bucket';
       mockSearch.mockResolvedValue(createMockErrorResponse(404));
 
-      const result = await adapter.getRecords(bucket);
-
-      expect(result.records).toEqual([]);
+      await expect(adapter.getRecords(bucket)).rejects.toThrow(
+        'OpenSearch error: 404',
+      );
     });
 
     it('should handle OpenSearch client errors gracefully', async () => {
@@ -434,14 +434,14 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when OpenSearch returns error', async () => {
+    it('should throw when OpenSearch returns error', async () => {
       const bucket = 'test-bucket';
       const id = 'test-id';
       mockSearch.mockResolvedValue(createMockErrorResponse(404));
 
-      const result = await adapter.getRecord(bucket, id);
-
-      expect(result).toBeNull();
+      await expect(adapter.getRecord(bucket, id)).rejects.toThrow(
+        'OpenSearch error: 404',
+      );
     });
 
     it('should return null when response has malformed structure', async () => {
@@ -692,7 +692,7 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
       await expect(adapter.store(record)).rejects.toThrow('ETIMEDOUT');
     });
 
-    it('should handle authentication errors', async () => {
+    it('should throw on authentication errors', async () => {
       const bucket = 'test-bucket';
       mockSearch.mockResolvedValue({
         statusCode: 401,
@@ -704,12 +704,12 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
         },
       });
 
-      const result = await adapter.getRecords(bucket);
-
-      expect(result.records).toEqual([]);
+      await expect(adapter.getRecords(bucket)).rejects.toThrow(
+        'OpenSearch error: 401',
+      );
     });
 
-    it('should handle index not found errors', async () => {
+    it('should throw on index not found errors', async () => {
       const bucket = 'test-bucket';
       mockSearch.mockResolvedValue({
         statusCode: 404,
@@ -721,9 +721,9 @@ describe('OpenSearchStorageAdapter - Specific Implementation', () => {
         },
       });
 
-      const result = await adapter.getRecords(bucket);
-
-      expect(result.records).toEqual([]);
+      await expect(adapter.getRecords(bucket)).rejects.toThrow(
+        'OpenSearch error: 404',
+      );
     });
   });
 

--- a/server/storage/opensearch.ts
+++ b/server/storage/opensearch.ts
@@ -94,7 +94,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
     });
 
     if (res.statusCode !== 200) {
-      return { records: [] };
+      throw new Error(`OpenSearch error: ${res.statusCode}`);
     }
 
     // Handle malformed response
@@ -146,7 +146,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
     });
 
     if (res.statusCode !== 200) {
-      return null;
+      throw new Error(`OpenSearch error: ${res.statusCode}`);
     }
 
     // Handle malformed response


### PR DESCRIPTION
## Summary

Refs #34 (third High-priority item: stop masking 5xx as 404 in the read API).

- `server/routes/api.ts`: catch blocks now return `500 Internal server error` instead of masking storage failures as `200 { records: [] }` or `404 Record not found`
- `server/storage/opensearch.ts`: non-200 HTTP responses from OpenSearch now throw instead of silently returning empty/null, so failures propagate to the API layer
- `client/Bucket.tsx` / `client/RequestRecordView.tsx`: add `error` state; surface storage errors as a visible banner; `RequestRecordView` distinguishes 404 (record not found) from 5xx (storage error)
- `client/style.css`: add `.error-message` style
- `server/routes/__tests__/api.test.ts`: new test file covering success, not-found, and storage-error cases for both handlers

## Test plan

- [x] `bun test` — all 91 tests pass
- [x] `bun run typecheck` — no errors
- [x] `bun run check` — no lint issues
- [x] Manual: normal bucket view works unchanged
- [ ] Manual: when storage throws, the UI shows an error banner instead of an empty list or silent 404