### PR TITLE
refactor: split Bucket.tsx into custom hooks

### DIFF
--- a/client/Bucket.tsx
+++ b/client/Bucket.tsx
@@ -1,150 +1,36 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Link, useParams } from 'react-router';
-import type { RequestRecord } from '../common/types';
+import { useBucketRecords } from './hooks/useBucketRecords';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { usePolling } from './hooks/usePolling';
+import { useTabVisibility } from './hooks/useTabVisibility';
 import RecordingGuide from './RecordingGuide';
 import RequestRecordComponent from './RequestRecordComponent';
 
 function Bucket({ ...props }: React.ComponentProps<'div'>) {
   const { bucket } = useParams<{ bucket: string }>();
-  const [records, setRecords] = useState<
-    (RequestRecord & { loaded?: boolean; isNew?: boolean })[]
-  >([]);
-  const [nextLink, setNextLink] = useState<string | null>(null);
+
+  const {
+    records,
+    nextLink,
+    latestTimestamp,
+    error,
+    loadedRef,
+    load,
+    pollNewRecords,
+  } = useBucketRecords(bucket);
+
   const [isPollingEnabled, setIsPollingEnabled] = useState(false);
-  const [latestTimestamp, setLatestTimestamp] = useState<string | null>(null);
-  const [isTabVisible, setIsTabVisible] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const loadedRef = useRef<HTMLDivElement>(null);
+  const isTabVisible = useTabVisibility();
 
-  const hasRecords = records != null && records.length > 0;
-
-  const load = useCallback(
-    async (from: string | undefined = undefined) => {
-      if (bucket == null) {
-        return;
-      }
-
-      const uri = from ?? `/api/bucket/${bucket}/record/`;
-
-      try {
-        const res = await fetch(uri, {
-          method: 'GET',
-        });
-        if (res.ok) {
-          setError(null);
-          const body = await res.json();
-
-          const loaded = body.records;
-          setRecords((prev) => {
-            const items = from != null ? [...prev, ...loaded] : loaded;
-            if (from != null) {
-              items[prev.length].loaded = true;
-            }
-            return items;
-          });
-
-          if (loaded.length > 0 && from == null) {
-            setLatestTimestamp(loaded[0].timestamp);
-          } else if (loaded.length === 0 && from == null) {
-            setLatestTimestamp(new Date().toISOString());
-          }
-
-          if (body.next != null) {
-            setNextLink(body.next);
-          } else {
-            setNextLink(null);
-          }
-
-          if (from != null) {
-            setTimeout(() => {
-              loadedRef.current?.scrollIntoView({
-                behavior: 'smooth',
-                block: 'start',
-              });
-            }, 100);
-          }
-        } else {
-          setError('Failed to load records from storage.');
-        }
-      } catch (err) {
-        console.error(err);
-        setError('Failed to load records from storage.');
-      }
-    },
-    [bucket],
+  useDocumentTitle(bucket ? `request-bucket: ${bucket}` : null);
+  usePolling(
+    pollNewRecords,
+    5000,
+    isPollingEnabled && !!latestTimestamp && isTabVisible,
   );
 
-  const pollNewRecords = useCallback(async () => {
-    if (!bucket || !latestTimestamp || !isPollingEnabled) {
-      return;
-    }
-
-    try {
-      const res = await fetch(
-        `/api/bucket/${bucket}/record/?since=${encodeURIComponent(latestTimestamp)}`,
-        {
-          method: 'GET',
-        },
-      );
-      if (res.ok) {
-        setError(null);
-        const body = await res.json();
-        const newRecords = body.records;
-
-        if (newRecords.length > 0) {
-          const markedRecords = newRecords.map((r: RequestRecord) => ({
-            ...r,
-            isNew: true,
-          }));
-          setRecords((prev) => [...markedRecords, ...prev]);
-
-          setLatestTimestamp(newRecords[0].timestamp);
-        }
-      } else {
-        setError('Auto-refresh failed: storage error.');
-      }
-    } catch (err) {
-      console.error('Polling error:', err);
-      setError('Auto-refresh failed: storage error.');
-    }
-  }, [bucket, latestTimestamp, isPollingEnabled]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    if (bucket) {
-      document.title = `request-bucket: ${bucket}`;
-    }
-    return () => {
-      document.title = 'request-bucket';
-    };
-  }, [bucket]);
-
-  // Track page visibility
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      setIsTabVisible(!document.hidden);
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, []);
-
-  // Polling effect
-  useEffect(() => {
-    if (!isPollingEnabled || !latestTimestamp || !isTabVisible) {
-      return;
-    }
-
-    const intervalId = setInterval(pollNewRecords, 5000); // Poll every 5 seconds
-
-    return () => clearInterval(intervalId);
-  }, [latestTimestamp, isPollingEnabled, isTabVisible, pollNewRecords]);
+  const hasRecords = records.length > 0;
 
   return (
     <div {...props}>
@@ -181,7 +67,7 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
 
       {hasRecords && <h2>Requests</h2>}
 
-      {records?.map((record) => (
+      {records.map((record) => (
         <RequestRecordComponent
           ref={record.loaded ? loadedRef : undefined}
           key={record.id}

--- a/client/hooks/useBucketRecords.ts
+++ b/client/hooks/useBucketRecords.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RequestRecord } from '../../common/types';
+
+export type BucketRecord = RequestRecord & {
+  loaded?: boolean;
+  isNew?: boolean;
+};
+
+export interface UseBucketRecordsReturn {
+  records: BucketRecord[];
+  nextLink: string | null;
+  latestTimestamp: string | null;
+  error: string | null;
+  loadedRef: React.RefObject<HTMLDivElement | null>;
+  load: (from?: string) => Promise<void>;
+  pollNewRecords: () => Promise<void>;
+}
+
+export function useBucketRecords(
+  bucket: string | undefined,
+): UseBucketRecordsReturn {
+  const [records, setRecords] = useState<BucketRecord[]>([]);
+  const [nextLink, setNextLink] = useState<string | null>(null);
+  const [latestTimestamp, setLatestTimestamp] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const loadedRef = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(
+    async (from: string | undefined = undefined) => {
+      if (bucket == null) {
+        return;
+      }
+
+      const uri = from ?? `/api/bucket/${bucket}/record/`;
+
+      try {
+        const res = await fetch(uri, { method: 'GET' });
+        if (res.ok) {
+          setError(null);
+          const body = await res.json();
+          const loaded = body.records;
+
+          setRecords((prev) => {
+            const items = from != null ? [...prev, ...loaded] : loaded;
+            if (from != null) {
+              items[prev.length].loaded = true;
+            }
+            return items;
+          });
+
+          if (loaded.length > 0 && from == null) {
+            setLatestTimestamp(loaded[0].timestamp);
+          } else if (loaded.length === 0 && from == null) {
+            setLatestTimestamp(new Date().toISOString());
+          }
+
+          setNextLink(body.next ?? null);
+
+          if (from != null) {
+            setTimeout(() => {
+              loadedRef.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+              });
+            }, 100);
+          }
+        } else {
+          setError('Failed to load records from storage.');
+        }
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load records from storage.');
+      }
+    },
+    [bucket],
+  );
+
+  const pollNewRecords = useCallback(async () => {
+    if (!bucket || !latestTimestamp) {
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/bucket/${bucket}/record/?since=${encodeURIComponent(latestTimestamp)}`,
+        { method: 'GET' },
+      );
+      if (res.ok) {
+        setError(null);
+        const body = await res.json();
+        const newRecords = body.records;
+
+        if (newRecords.length > 0) {
+          const markedRecords = newRecords.map((r: RequestRecord) => ({
+            ...r,
+            isNew: true,
+          }));
+          setRecords((prev) => [...markedRecords, ...prev]);
+          setLatestTimestamp(newRecords[0].timestamp);
+        }
+      } else {
+        setError('Auto-refresh failed: storage error.');
+      }
+    } catch (err) {
+      console.error('Polling error:', err);
+      setError('Auto-refresh failed: storage error.');
+    }
+  }, [bucket, latestTimestamp]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return {
+    records,
+    nextLink,
+    latestTimestamp,
+    error,
+    loadedRef,
+    load,
+    pollNewRecords,
+  };
+}

--- a/client/hooks/useDocumentTitle.ts
+++ b/client/hooks/useDocumentTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export function useDocumentTitle(title: string | null | undefined): void {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+    return () => {
+      document.title = 'request-bucket';
+    };
+  }, [title]);
+}

--- a/client/hooks/usePolling.ts
+++ b/client/hooks/usePolling.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+export function usePolling(
+  callback: () => void | Promise<void>,
+  intervalMs: number,
+  enabled: boolean,
+): void {
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => {
+      callbackRef.current();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [enabled, intervalMs]);
+}

--- a/client/hooks/useTabVisibility.ts
+++ b/client/hooks/useTabVisibility.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export function useTabVisibility(): boolean {
+  const [isVisible, setIsVisible] = useState(!document.hidden);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsVisible(!document.hidden);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isVisible;
+}


### PR DESCRIPTION
## Summary

Addresses #34 (Medium priority, item 1: split `Bucket.tsx` into custom hooks).

Extracts four custom hooks from `client/Bucket.tsx` into `client/hooks/`:

- `useBucketRecords(bucket)` — record loading, pagination, and polling callback
- `usePolling(callback, intervalMs, enabled)` — `setInterval` management with a `useRef`-based stable callback to avoid stale closures
- `useTabVisibility()` — `document.visibilitychange` tracking
- `useDocumentTitle(title)` — `document.title` updates with cleanup

`Bucket.tsx` now only owns `isPollingEnabled` state and wires the hooks together; all `useCallback`/`useEffect`/`useRef` calls have moved into their respective hooks.

## Test plan

- [x] Open a bucket URL — initial records load correctly
- [x] Click "Load more" — additional records append and scroll into view
- [x] Enable Auto-refresh, send a new request — new record appears within 5 seconds
- [x] Hide the tab (switch away) — polling pauses; restore tab — polling resumes
- [x] Click "Refresh" manually — records reload
- [x] Verify page title shows `request-bucket: <bucket>` while on the bucket page, resets on navigation away
- [x] `bun run typecheck` passes
- [x] `bun run check` passes