### PR TITLE
refactor: remove OpenSearch-specific _id from shared RequestRecord type

### DIFF
--- a/client/Bucket.tsx
+++ b/client/Bucket.tsx
@@ -72,7 +72,6 @@ function Bucket({ ...props }: React.ComponentProps<'div'>) {
           ref={record.loaded ? loadedRef : undefined}
           key={record.id}
           id={record.id}
-          data-osid={record._id}
           record={record}
           linkToItem={`/bucket/${record.bucket}/${record.id}`}
         />

--- a/client/RequestRecordView.tsx
+++ b/client/RequestRecordView.tsx
@@ -68,7 +68,6 @@ function RequestRecordView({ ...props }: React.ComponentProps<'div'>) {
         <RequestRecordComponent
           key={record.id}
           id={record.id}
-          data-osid={record._id}
           record={record}
         />
       )}

--- a/common/types.ts
+++ b/common/types.ts
@@ -8,7 +8,6 @@ export type JsonBody =
 
 export type RequestRecord = {
   id?: string;
-  _id?: string;
   timestamp: string;
   bucket: string;
   request: {

--- a/server/storage/opensearch.ts
+++ b/server/storage/opensearch.ts
@@ -104,7 +104,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
 
     const hits = (res.body.hits.hits as SearchHit<RequestRecord>[])
       .filter((hit) => hit._source != null)
-      .map((hit) => ({ ...hit._source, _id: hit._id }) as RequestRecord)
+      .map((hit) => hit._source as RequestRecord)
       .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
 
     if (hits.length > limit) {
@@ -156,7 +156,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
 
     const records = (res.body.hits.hits as SearchHit<RequestRecord>[])
       .filter((hit) => hit._source != null)
-      .map((hit) => ({ ...hit._source, _id: hit._id }) as RequestRecord)
+      .map((hit) => hit._source as RequestRecord)
       .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
 
     return records.length > 0 ? records[0] : null;


### PR DESCRIPTION
## Summary

- Removes `_id?: string` from the shared `RequestRecord` type in `common/types.ts` — this field was an OpenSearch internal document identifier leaking into the shared type layer
- Stops injecting `_id: hit._id` into returned records in `OpenSearchStorageAdapter` (`getRecords` and `getRecord`); the application's own UUID is already carried in the `id` field
- Removes `data-osid={record._id}` debug attributes from `Bucket.tsx` and `RequestRecordView.tsx`

Related to #34 (Medium priority item 2).

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun test` — all 91 tests pass
- [x] `bun run check` — no lint/format issues