### PR TITLE
refactor: extract parseHits() to deduplicate hit parsing in OpenSearchStorageAdapter

### DIFF
--- a/server/storage/opensearch.ts
+++ b/server/storage/opensearch.ts
@@ -27,6 +27,13 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
     this.ignoreHeaderPrefixes = ignoreHeaderPrefixes;
   }
 
+  private parseHits(rawHits: unknown): RequestRecord[] {
+    return (rawHits as SearchHit<RequestRecord>[])
+      .filter((hit) => hit._source != null)
+      .map((hit) => hit._source as RequestRecord)
+      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
+  }
+
   async store(record: RequestRecord): Promise<void> {
     const res = await this.client.index({
       index: this.index,
@@ -102,10 +109,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
       return { records: [] };
     }
 
-    const hits = (res.body.hits.hits as SearchHit<RequestRecord>[])
-      .filter((hit) => hit._source != null)
-      .map((hit) => hit._source as RequestRecord)
-      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
+    const hits = this.parseHits(res.body.hits.hits);
 
     if (hits.length > limit) {
       const last = hits.pop();
@@ -154,10 +158,7 @@ export class OpenSearchStorageAdapter implements StorageAdapter {
       return null;
     }
 
-    const records = (res.body.hits.hits as SearchHit<RequestRecord>[])
-      .filter((hit) => hit._source != null)
-      .map((hit) => hit._source as RequestRecord)
-      .map((record) => filterHeaders(record, this.ignoreHeaderPrefixes));
+    const records = this.parseHits(res.body.hits.hits);
 
     return records.length > 0 ? records[0] : null;
   }


### PR DESCRIPTION
## Summary

- Extracts a private `parseHits()` method in `OpenSearchStorageAdapter` that encapsulates the common `hits → RequestRecord[]` conversion chain (`.filter().map().map()`)
- Replaces the two identical inline chains in `getRecords()` and `getRecord()` with calls to the new method

Implements #34 (Medium priority item: "Deduplicate hit parsing in `OpenSearchStorageAdapter`").

## Test plan

- [x] All existing tests pass (`bun test server/storage/__tests__/opensearch.test.ts` — 48 tests)
- [x] No type errors (`bun run typecheck`)