### PR TITLE
refactor: unify storage barrel imports and tidy hook.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,7 @@ import { withLogging } from './middleware/logging';
 import { createGetRecordHandler, createGetRecordsHandler } from './routes/api';
 import { createHookHandler } from './routes/hook';
 import { staticHandler } from './static';
-import { createStorageFromEnv } from './storage/factory';
+import { createStorageFromEnv } from './storage';
 
 const dev = process.env.NODE_ENV !== 'production';
 const port = Number(process.env.PORT ?? 3000);

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -1,4 +1,4 @@
-import type { StorageAdapter } from '../storage/interface';
+import type { StorageAdapter } from '../storage';
 
 const ITEMS_PER_PAGE = 5;
 

--- a/server/routes/hook.ts
+++ b/server/routes/hook.ts
@@ -1,6 +1,6 @@
 import { Buffer, isUtf8 } from 'node:buffer';
 import type { JsonBody, RequestRecord } from '../../common/types';
-import type { StorageAdapter } from '../storage/interface';
+import type { StorageAdapter } from '../storage';
 import { uuid58 } from '../uuid58';
 
 const parseRequestBody = (
@@ -31,6 +31,8 @@ const parseRequestBody = (
   return { bodyRaw };
 };
 
+// TODO: does not handle bare IPv6 addresses like [::1] (no port). lastIndexOf(':')
+// misidentifies the final ':' inside brackets as a port separator, yielding a wrong host.
 const parseHostHeader = (
   hostHeader: string | null,
   fallbackHost: string,
@@ -81,10 +83,7 @@ export const createHookHandler = (storage: StorageAdapter) => {
 
     const rawBody = Buffer.from(await req.arrayBuffer());
 
-    const headers: Record<string, string> = {};
-    req.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
+    const headers: Record<string, string> = Object.fromEntries(req.headers);
 
     const id = uuid58();
 
@@ -99,7 +98,7 @@ export const createHookHandler = (storage: StorageAdapter) => {
         port,
         pathQuery,
         path,
-        args: ['', ...paths.slice(1)].join('/'),
+        args: `/${paths.slice(1).join('/')}`,
         queryString,
         query: Object.fromEntries(url.searchParams),
         headers,


### PR DESCRIPTION
Implements part of #34 (low-priority items 1 and 2).

## Changes

### Item 1 — Consistent storage barrel imports

`server/storage/index.ts` already re-exports the full public storage API, but callers were bypassing it. Updated all three server-side files to import through the barrel:

- `server/index.ts`: `./storage/factory` → `./storage`
- `server/routes/api.ts`: `../storage/interface` → `../storage`
- `server/routes/hook.ts`: `../storage/interface` → `../storage`

### Item 2 — Tidy `server/routes/hook.ts`

- Replace 4-line `req.headers.forEach` accumulator with `Object.fromEntries(req.headers)`
- Simplify `args` path construction: `['', ...paths.slice(1)].join('/')` → `` `/${paths.slice(1).join('/')}` ``
- Add TODO comment on `parseHostHeader` documenting the known IPv6 limitation (bare `[::1]` without port is misparsed)

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun run check` — no lint/format issues
- [x] `bun test` — 91 tests pass