### PR TITLE
refactor: use string comparison in MemoryStorageAdapter sort comparator

### DIFF
--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -20,10 +20,9 @@ export class MemoryStorageAdapter implements StorageAdapter {
     const bucketRecords = this.records.get(bucket) as RequestRecord[];
     bucketRecords.push(record);
 
-    // Sort by timestamp descending to maintain order
-    bucketRecords.sort(
-      (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    // ISO 8601 strings are lexicographically orderable, no Date parsing needed
+    bucketRecords.sort((a, b) =>
+      b.timestamp > a.timestamp ? 1 : b.timestamp < a.timestamp ? -1 : 0,
     );
   }
 


### PR DESCRIPTION
## Summary

- Replaces `new Date(ts).getTime()` calls in the sort comparator with direct string comparison
- ISO 8601 strings (`.toISOString()` output) are lexicographically ordered identically to their numeric values, so string comparison is correct and avoids unnecessary `Date` object allocations

## Test plan

- [x] All 34 existing `memory.test.ts` tests pass
- [x] `bun run typecheck` passes
- [x] `bun run check` passes

Implements part of #34 (Low priority: avoid unnecessary `new Date` allocations in sort comparator).