### PR TITLE
refactor: move getBucketStats/clear to test-only subclass

### DIFF
--- a/server/storage/__tests__/helpers.ts
+++ b/server/storage/__tests__/helpers.ts
@@ -1,4 +1,19 @@
 import type { RequestRecord } from '../../../common/types';
+import { MemoryStorageAdapter } from '../memory';
+
+export class TestableMemoryStorageAdapter extends MemoryStorageAdapter {
+  getBucketStats(): { [bucket: string]: number } {
+    const stats: { [bucket: string]: number } = {};
+    for (const [bucket, records] of this.records) {
+      stats[bucket] = records.length;
+    }
+    return stats;
+  }
+
+  clear(): void {
+    this.records.clear();
+  }
+}
 
 export const createSampleRecord = (
   id: string,

--- a/server/storage/__tests__/memory.test.ts
+++ b/server/storage/__tests__/memory.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { MemoryStorageAdapter } from '../memory';
-import { createSampleRecord } from './helpers';
+import { createSampleRecord, TestableMemoryStorageAdapter } from './helpers';
 import { createStorageInterfaceTests } from './shared/storage-interface.test';
 
 // Run shared interface tests
@@ -10,10 +10,10 @@ createStorageInterfaceTests(
 );
 
 describe('MemoryStorageAdapter - Specific Implementation', () => {
-  let adapter: MemoryStorageAdapter;
+  let adapter: TestableMemoryStorageAdapter;
 
   beforeEach(() => {
-    adapter = new MemoryStorageAdapter();
+    adapter = new TestableMemoryStorageAdapter();
   });
 
   describe('constructor', () => {

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -3,6 +3,7 @@ import type { StorageAdapter } from './interface';
 import { filterHeaders } from './utils';
 
 export class MemoryStorageAdapter implements StorageAdapter {
+  // protected to allow test subclasses (e.g. TestableMemoryStorageAdapter) to access internals
   protected records: Map<string, RequestRecord[]> = new Map();
   private ignoreHeaderPrefixes: string[];
 

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -77,5 +77,4 @@ export class MemoryStorageAdapter implements StorageAdapter {
 
     return record ? filterHeaders(record, this.ignoreHeaderPrefixes) : null;
   }
-
 }

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -3,7 +3,7 @@ import type { StorageAdapter } from './interface';
 import { filterHeaders } from './utils';
 
 export class MemoryStorageAdapter implements StorageAdapter {
-  private records: Map<string, RequestRecord[]> = new Map();
+  protected records: Map<string, RequestRecord[]> = new Map();
   private ignoreHeaderPrefixes: string[];
 
   constructor(ignoreHeaderPrefixes: string[] = []) {
@@ -78,17 +78,4 @@ export class MemoryStorageAdapter implements StorageAdapter {
     return record ? filterHeaders(record, this.ignoreHeaderPrefixes) : null;
   }
 
-  // Utility method for debugging/monitoring
-  getBucketStats(): { [bucket: string]: number } {
-    const stats: { [bucket: string]: number } = {};
-    for (const [bucket, records] of this.records) {
-      stats[bucket] = records.length;
-    }
-    return stats;
-  }
-
-  // Clear all data (useful for testing)
-  clear(): void {
-    this.records.clear();
-  }
 }


### PR DESCRIPTION
## Summary

- Remove `getBucketStats()` and `clear()` from `MemoryStorageAdapter` — these methods are not part of the `StorageAdapter` interface and had no production consumers
- Change `private records` to `protected` to allow subclass access
- Introduce `TestableMemoryStorageAdapter` in `__tests__/helpers.ts` that extends `MemoryStorageAdapter` and adds the two test-only methods
- Update `memory.test.ts` to use `TestableMemoryStorageAdapter` for the utility method tests

Closes #34 (Low priority item: decide the fate of `getBucketStats` / `clear` on `MemoryStorageAdapter`)

## Test plan

- [x] All existing tests pass (`bun test`)
- [x] Type check passes (`bun run typecheck`)