### PR TITLE
fix: update bump-version.sh to use bun instead of npm

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,11 +20,11 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
-NEW_VERSION=$(npm version "$BUMP" --no-git-tag-version | sed 's/^v//')
+NEW_VERSION=$(bun version "$BUMP" | sed 's/^v//')
 BRANCH="release/v${NEW_VERSION}"
 
 git checkout -b "$BRANCH"
-git add package.json package-lock.json
+git add package.json bun.lock
 git commit -m "chore: bump version to v${NEW_VERSION}"
 git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary

- Replace `npm version` with `bun version` for version bumping
- Replace `package-lock.json` with `bun.lock` in the `git add` step

## Background

The project uses Bun as the runtime, so `package-lock.json` is not generated. This fix aligns the release script with the actual lockfile (`bun.lock`) and uses Bun's built-in version command.