### PR TITLE
fix: revert bun version to npm version and drop bun.lock from git add

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,11 +20,11 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
-NEW_VERSION=$(bun version "$BUMP" | sed 's/^v//')
+NEW_VERSION=$(npm version "$BUMP" | sed 's/^v//')
 BRANCH="release/v${NEW_VERSION}"
 
 git checkout -b "$BRANCH"
-git add package.json bun.lock
+git add package.json
 git commit -m "chore: bump version to v${NEW_VERSION}"
 git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary

- `bun version` is not a valid command; revert to `npm version` which correctly bumps `package.json` even in Bun projects
- `bun.lock` does not record the package's own version, so remove it from the `git add` targets (only `package.json` needs to be staged)

## Test plan

- [ ] Run `npm version patch --dry-run` to verify the command works and outputs the expected version string
- [ ] Run `bash scripts/bump-version.sh patch` on a clean branch to confirm the full flow completes without errors