### PR TITLE
fix: add --no-git-tag-version to npm version in bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,7 +20,7 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
-NEW_VERSION=$(npm version "$BUMP" | sed 's/^v//')
+NEW_VERSION=$(npm version "$BUMP" --no-git-tag-version | sed 's/^v//')
 BRANCH="release/v${NEW_VERSION}"
 
 git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary

- Add `--no-git-tag-version` flag to `npm version` call in `bump-version.sh`
- Without this flag, `npm version` automatically creates a git commit and tag, conflicting with the manual `git add` / `git commit` steps that follow

## Test plan

- [ ] Run `scripts/bump-version.sh patch` on the default branch and verify it creates a release branch and PR without duplicate commits or tags