### PR TITLE
chore: bump version to v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "request-bucket",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "author": "dayflower",
   "repository": {


### PR DESCRIPTION
Bumps version to `v0.8.0`. Merging this PR will automatically create the git tag, build Docker images, and publish a GitHub Release.