### PR TITLE
Add explicit permissions to CI and Test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `ci.yml` and `test.yml` to fix GitHub code scanning warning: _Workflow does not contain permissions_
- Both workflows only perform read-only operations (checkout, lint, type-check, test), so `contents: read` is the appropriate minimal permission

## Test plan

- [x] Confirm CI workflow passes on this PR
- [ ] Confirm code scanning no longer reports "Workflow does not contain permissions" for these workflows